### PR TITLE
Fix resource path in windows

### DIFF
--- a/src/main/scala/play/doc/PlayDoc.scala
+++ b/src/main/scala/play/doc/PlayDoc.scala
@@ -161,7 +161,7 @@ class PlayDoc(markdownRepository: FileRepository, codeRepository: FileRepository
         val sourceFile = if (source.startsWith("/")) {
           repo(source.drop(1))
         } else {
-          repo(pagePath + source)
+          repo(pagePath.replace("\\", "/"") + source)
         }
 
         val labelPattern = ("""\s*#\Q""" + label + """\E(\s|\z)""").r

--- a/src/main/scala/play/doc/PlayDoc.scala
+++ b/src/main/scala/play/doc/PlayDoc.scala
@@ -88,7 +88,7 @@ class PlayDoc(markdownRepository: FileRepository, codeRepository: FileRepository
         val link = image match {
           case full if full.startsWith("http://") => full
           case absolute if absolute.startsWith("/") => resources + absolute
-          case relative => resources + "/" + relativePath.map(_.getPath + "/").getOrElse("") + relative
+          case relative => resources + "/" + relativePath.map(_.getPath.replace("\\", "/") + "/").getOrElse("") + relative
         }
         (link, """<img src="""" + link + """"/>""")
       }


### PR DESCRIPTION
Currently image does not show if run in windows, e.g. in @documentation/ScalaForms
