### PR TITLE
Add anchor while rendering HTML header

### DIFF
--- a/src/test/scala/play/doc/PlayDocSpec.scala
+++ b/src/test/scala/play/doc/PlayDocSpec.scala
@@ -78,4 +78,13 @@ object PlayDocSpec extends Specification {
     }
   }
 
+  "play header" should {
+    "be h1 with anchor" in {
+      renderer.render("# Header level 1") must_== """<h1><a name="header-level-1">Header level 1</a></h1>"""
+    }
+
+    "be h3 with anchor" in {
+      renderer.render("###   % Header § level 3 ") must_== """<h3><a name="--header---level-3">% Header § level 3</a></h3>"""
+    }
+  }
 }


### PR DESCRIPTION
When markdown header like `# Header` is encountered, renders it in HTML including an anchor `<h1><a name="header">Header</a></h1>`.

It makes easier to have link pointing to specific documentation section.

Anchor is generated by normalizing header node content (children). For example:

```
# Header 1
##   % An header 2 with not alphanum char like § or ⇒
```

... is rendered in HTML as following:

``` html
<h1><a name="header-1">Header 1</a></h1>
<h2><a name="--an-header-2-with-not-alphanum-char-like---or--">% An header 2 with not alphanum char like § or ⇒</a></h2>
```
