### PR TITLE
Add section marker to headlines

### DIFF
--- a/src/main/scala/play/doc/PlayDoc.scala
+++ b/src/main/scala/play/doc/PlayDoc.scala
@@ -213,12 +213,26 @@ class PlayDoc(markdownRepository: FileRepository, codeRepository: FileRepository
             }.flatten
           }
           val title = collectTextNodes(node).mkString
+          val anchorId = headingToAnchor(title)
 
-          printer.print(headingToAnchor(title))
+          printer.print(anchorId)
             .print("\"")
+
+          printer.print(">")
+
+          // Add section marker
+          printer.print("<a class=\"section-marker\" href=\"")
+            .print(s"#$anchorId")
+            .print("\"")
+            .print(">")
+            .print("§")
+            .print("</a>")
+        }
+        else {
+          printer.print(">")
         }
 
-        printer.print(">")
+
         visitChildren(node)
         printer.print("</h").print(node.getLevel.toString).print(">")
       }


### PR DESCRIPTION
This adds a section marker to all headlines in the documentation. A section marker is an icon with an anchor / link to the id of the current headline.

**Example**
![screen shot 2015-07-14 at 18 42 19](https://cloud.githubusercontent.com/assets/1832216/8678978/2f615b1e-2a58-11e5-8a62-544d08804a88.png)

We want to introduce this to the ConductR documentation. The corresponding PR in [project-doc](https://github.com/typesafehub/project-doc) is [#39](https://github.com/typesafehub/project-doc/pull/39). This PR adds the CSS styling `section-marker` which is generated by `play-doc` for each headline.

I've also created the PR [#33](https://github.com/playframework/playframework.com/pull/33) at [playframework.com](https://github.com/playframework/playframework.com) which adds the corresponding CSS to the playframework.com website. Couldn't really tests playframework.com because I don't know how to re-generate the `play-generated-docs` (which would include now the anchor icon for each headline).

@richdougherty @jroper: Can one of you please review the change and let me know how I can re-generate the HTML to test the anchor icons. 