### PR TITLE
Removed double header links

### DIFF
--- a/src/main/scala/play/doc/PlayDoc.scala
+++ b/src/main/scala/play/doc/PlayDoc.scala
@@ -197,7 +197,7 @@ class PlayDoc(markdownRepository: FileRepository, codeRepository: FileRepository
     }
 
     // Markdown parser
-    val processor = new PegDownProcessor(Extensions.ALL, PegDownPlugins.builder()
+    val processor = new PegDownProcessor(Extensions.ALL & ~Extensions.ANCHORLINKS, PegDownPlugins.builder()
       .withPlugin(classOf[CodeReferenceParser])
       .withPlugin(classOf[VariableParser], PlayVersionVariableName)
       .withPlugin(classOf[TocParser])

--- a/src/test/scala/play/doc/PlayDocSpec.scala
+++ b/src/test/scala/play/doc/PlayDocSpec.scala
@@ -117,4 +117,11 @@ class PlayDocSpec extends Specification {
     }
   }
 
+  "header link rendering" should {
+    "render header links" in {
+      renderer.render("# Hello World") must_==
+        """<h1 id="Hello-World"><a class="section-marker" href="#Hello-World">§</a>Hello World</h1>"""
+    }
+  }
+
 }


### PR DESCRIPTION
play-doc has supported header links for quite some time, but recently it was upgraded to a version of pegdown that also added header links, using a slightly different approach, which meant headings now had double anchors, and two different link styles.

This turns off pegdowns header links support, so that it only uses the old approach that we added.