### PR TITLE
Cross build against Scala 2.12 because it's need by a sbt-plugin

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,7 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v2
     with:
       java: 11, 8
-      scala: 2.13.8
+      scala: 2.12.15, 2.13.8
       cmd: sbt ++$MATRIX_SCALA test
 
   finish:

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import interplay.ScalaVersions._
+
 // Customise sbt-dynver's behaviour to make it work with tags which aren't v-prefixed
 (ThisBuild / dynverVTagPrefix) := false
 
@@ -10,6 +12,9 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
 
 lazy val `play-doc` = (project in file("."))
   .enablePlugins(PlayLibrary, SbtTwirl, PlayReleaseBase)
+  .settings(
+    crossScalaVersions := Seq(scala212, scala213)
+  )
 
 libraryDependencies ++= Seq(
   "org.pegdown" % "pegdown"     % "1.6.0",


### PR DESCRIPTION
The project is defined as interplay `PlayLibrary`, which however dropped Scala 2.12, because a `PlayLibrary` is meant to be used for libraries not for plugins. But [play-doc is also used for an sbt-plugin](https://github.com/playframework/playframework/blob/23efe03e8d3d3a2604efe7d660c1f1c210e432bc/project/Dependencies.scala#L302-L304),  so we need to explicitly build for 2.12. (And yes I know interplay should be gone soon)