### PR TITLE
Explicitly upgrade pegdown's transitive parboiled-java dependency

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   check-code-style:
     name: Code Style
-    uses: playframework/.github/.github/workflows/cmd.yml@v2
+    uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       cmd: sbt validateCode
 
@@ -23,9 +23,9 @@ jobs:
     name: Tests
     needs:
       - "check-code-style"
-    uses: playframework/.github/.github/workflows/cmd.yml@v2
+    uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
-      java: 11, 8
+      java: 17, 11
       scala: 2.12.15, 2.13.8
       cmd: sbt ++$MATRIX_SCALA test
 
@@ -34,4 +34,4 @@ jobs:
     if: github.event_name == 'pull_request'
     needs: # Should be last
       - "tests"
-    uses: playframework/.github/.github/workflows/rtm.yml@v2
+    uses: playframework/.github/.github/workflows/rtm.yml@v3

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,7 @@ jobs:
     uses: playframework/.github/.github/workflows/cmd.yml@v3
     with:
       java: 17, 11
-      scala: 2.12.15, 2.13.8
+      scala: 2.12.17, 2.13.9
       cmd: sbt ++$MATRIX_SCALA test
 
   finish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,5 +11,5 @@ on:
 jobs:
   publish-artifacts:
     name: Publish / Artifacts
-    uses: playframework/.github/.github/workflows/publish.yml@v2
+    uses: playframework/.github/.github/workflows/publish.yml@v3
     secrets: inherit

--- a/build.sbt
+++ b/build.sbt
@@ -24,16 +24,15 @@ libraryDependencies ++= Seq(
 )
 
 javacOptions ++= Seq(
-  "-source",
-  "1.8",
-  "-target",
-  "1.8",
+  "--release",
+  "11",
   "-Xlint:deprecation",
   "-Xlint:unchecked",
 )
 
 scalacOptions ++= Seq(
-  "-target:jvm-1.8",
+  "-release",
+  "11",
   "-encoding",
   "utf8",
   "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -17,9 +17,10 @@ lazy val `play-doc` = (project in file("."))
   )
 
 libraryDependencies ++= Seq(
-  "org.pegdown" % "pegdown"     % "1.6.0",
-  "commons-io"  % "commons-io"  % "2.11.0",
-  "org.specs2" %% "specs2-core" % "4.16.1" % Test
+  ("org.pegdown"  % "pegdown"        % "1.6.0").exclude("org.parboiled", "parboiled-java"),
+  "org.parboiled" % "parboiled-java" % "1.4.1",
+  "commons-io"    % "commons-io"     % "2.11.0",
+  "org.specs2"   %% "specs2-core"    % "4.16.1" % Test
 )
 
 javacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
 }
 
 lazy val `play-doc` = (project in file("."))
-  .enablePlugins(PlayLibrary, SbtTwirl, PlayReleaseBase)
+  .enablePlugins(PlayLibrary, SbtTwirl)
   .settings(
     crossScalaVersions := Seq(scala212, scala213)
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "interplay"      % "3.0.5")
+addSbtPlugin("com.typesafe.play" % "interplay"      % "3.1.0-RC3")
 addSbtPlugin("com.typesafe.sbt"  % "sbt-twirl"      % "1.5.1")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"   % "2.4.6")
 addSbtPlugin("com.github.sbt"    % "sbt-ci-release" % "1.5.10")


### PR DESCRIPTION
To make the whole thing work with Java 11+, thanks to a newer transitive ASM dependency.

See explanation in https://github.com/playframework/play-doc/issues/35#issuecomment-1003689400

(Actually I did test all of this locally, published play-docs and used it in play and started the play documentation, everything worked fine. So we are lucky.)