### PR TITLE
Clear warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,11 +45,6 @@ javacOptions ++= Seq(
 scalacOptions ++= Seq(
   "-release",
   "11",
-  "-encoding",
-  "utf8",
-  "-deprecation",
-  "-feature",
-  "-unchecked",
 )
 
 (ThisBuild / playBuildRepoName) := "play-doc"

--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,6 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
   s
 }
 
-// lazy val scala212 = "2.12.17"
-// lazy val scala213 = "2.13.10"
-// lazy val scala3 = "3.2.2"
-
 lazy val `play-doc` = (project in file("."))
   .enablePlugins(PlayLibrary, SbtTwirl)
   .settings(


### PR DESCRIPTION
Add the compiler -rewrite flag
Add the compile source flag set to future-migration

The first compilation went fine but because of the -rewrite flag, the scala file are updated to Scala3 syntax. The second compilation fails as expected because the Scala2 compiler doesn't know about the new features.