### PR TITLE
Use Scala3 syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ lazy val `play-doc` = (project in file("."))
             "-Ywarn-unused:imports",
             "-Xlint:nullary-unit",
             "-Ywarn-dead-code",
+            "-Xsource:3",
           )
         case _ => Nil
       }

--- a/src/main/scala/play/doc/FileRepository.scala
+++ b/src/main/scala/play/doc/FileRepository.scala
@@ -5,7 +5,7 @@ import java.io.File
 import java.io.InputStream
 import java.util.jar.JarFile
 import java.util.zip.ZipEntry
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters.*
 
 /**
  * Access to file data, provided to the handler when `handleFile` is called.
@@ -103,7 +103,7 @@ class FilesystemRepository(base: File) extends FileRepository {
   def findFileWithName(name: String) = {
     def findFile(name: String)(dir: File): Option[File] = {
       dir.listFiles().find(file => file.isFile && file.getName.equalsIgnoreCase(name)).orElse {
-        dir.listFiles().filter(_.isDirectory).collectFirst(Function.unlift(findFile(name) _))
+        dir.listFiles().filter(_.isDirectory).collectFirst(Function.unlift(findFile(name)))
       }
     }
     findFile(name)(base).map(_.getAbsolutePath.drop(base.getAbsolutePath.size + 1))

--- a/src/main/scala/play/doc/PageIndex.scala
+++ b/src/main/scala/play/doc/PageIndex.scala
@@ -151,7 +151,7 @@ object PageIndex {
         TocPage(page, title, next)
       ) { content =>
         // https://github.com/scala/bug/issues/11125#issuecomment-423375868
-        val lines = augmentString(content).lines.toList.map(_.trim).filter(_.nonEmpty)
+        val lines = augmentString(content).linesIterator.toList.map(_.trim).filter(_.nonEmpty)
         // Remaining lines are the entries of the contents
         val tocNodes = lines.map { entry =>
           val linkAndTitle :: params = entry.split(";").toList

--- a/src/main/scala/play/doc/PlayDoc.scala
+++ b/src/main/scala/play/doc/PlayDoc.scala
@@ -4,12 +4,12 @@ import java.io.InputStream
 import java.io.File
 import java.util.Collections
 import java.util.Arrays
-import org.pegdown._
+import org.pegdown.*
 import org.pegdown.plugins.ToHtmlSerializerPlugin
 import org.pegdown.plugins.PegDownPlugins
-import org.pegdown.ast._
+import org.pegdown.ast.*
 import org.apache.commons.io.IOUtils
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters.*
 
 /**
  * A rendered page
@@ -264,7 +264,7 @@ class PlayDoc(
           if (headerIds) {
             printer.print(" id=\"")
 
-            import scala.collection.JavaConverters._
+            import scala.collection.JavaConverters.*
             def collectTextNodes(node: Node): Seq[String] = {
               node.getChildren.asScala.toSeq.flatMap {
                 case t: TextNode => Seq(t.getText)
@@ -315,7 +315,7 @@ class PlayDoc(
     // Most files will be accessed multiple times from the same markdown file, no point in opening them many times
     // so memoize them.  This cache is only per file rendered, so does not need to be thread safe.
     val repo = Memoize[String, Option[Seq[String]]] { path =>
-      codeRepository.loadFile(path) { is => IOUtils.readLines(is).asScala.toSeq }
+      codeRepository.loadFile(path) { is => IOUtils.readLines(is, "utf-8").asScala.toSeq }
     }
 
     def visit(node: Node, visitor: Visitor, printer: Printer) =


### PR DESCRIPTION
- Added the compiler flag `-Xsource:3` to compile Scala2 code as Scala3
- Migrated the code to use Scala3 syntax
- Replace deprecated syntax