### PR TITLE
Set `doc / javacOptions`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,7 @@ javacOptions ++= Seq(
   "-encoding",
   "UTF-8",
 )
+doc / javacOptions := Seq("-source", "11")
 
 scalacOptions ++= Seq(
   "-release",


### PR DESCRIPTION
In #206 I forget something:
Before #206  the `PlayLibrary` was activated, which is just a synonym for `PlayLibraryBase`, which also sets various configs:
https://github.com/playframework/interplay/blob/ad1bddb900e2883f7ad78e59c70fc86603903a52/src/main/scala/interplay/PlayLibraryBase.scala#L23-L35
The only releveant IMHO here is `doc / javacOptions`, so I copy that one over now.
We don't set `scalaVersion` explicitly now, but that does not matter IMHO.
