### PR TITLE
Twirl 2.1.0-M9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val `play-doc` = (project in file("."))
     organizationHomepage := Some(url("https://playframework.com")),
     homepage             := Some(url(s"https://github.com/playframework/${Omnidoc.repoName}")),
     licenses             := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
-    crossScalaVersions   := Seq("2.12.21", "2.13.18", "3.3.7"),
+    crossScalaVersions   := Seq("2.12.21", "2.13.18", "3.8.3"),
     developers += Developer(
       "playframework",
       "The Play Framework Contributors",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 // Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
 
-addSbtPlugin("org.playframework.twirl" % "sbt-twirl"      % "2.0.9")
+addSbtPlugin("org.playframework.twirl" % "sbt-twirl"      % "2.1.0-M9")
 addSbtPlugin("org.scalameta"           % "sbt-scalafmt"   % "2.5.6")
 addSbtPlugin("com.github.sbt"          % "sbt-ci-release" % "1.11.2")
 addSbtPlugin("com.github.sbt"          % "sbt-header"     % "5.11.0")


### PR DESCRIPTION
need to be able to run docs locally (because twirl renamed the `format` method)